### PR TITLE
Move ilib to dependencies from devDependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,9 @@ you check these files in to your source code control system.
 Release Notes
 -------------
 
+### 1.3.2
+Move ilib from devDependencies to dependencies.
+
 ### 1.3.1
 Fix to include automatically non-gregorian CalendarDate when using DateFactory or JS Date Object.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ilib-scanner",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "main": "./ilib-scanner.js",
     "bin": {
         "ilib-scanner": "./ilib-scanner.js",
@@ -48,9 +48,7 @@
         "node": ">=6.0"
     },
     "dependencies": {
+        "ilib": "^14.12.0",
         "options-parser": "^0.4.0"
-    },
-    "devDependencies": {
-        "ilib": "^14.12.0"
     }
 }


### PR DESCRIPTION
In order to ilib-scanner work properly, ilib has to be in dependencies. 
